### PR TITLE
fix: use "all" subcommand to apply to all files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command, Args, Parser, Subcommand, ValueEnum};
+use clap::{arg, command, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(about, version, arg_required_else_help = true)]
@@ -77,8 +77,12 @@ pub(crate) enum Subcommands {
     /// git-restore
     #[clap(alias = "rest")]
     Restore {
-        #[command(flatten)]
-        files: FileOperations,
+        /// which files to operate on
+        #[command(subcommand)]
+        which: Option<WhichFiles>,
+
+        /// Command arguments
+        args: Vec<String>,
     },
     /// Reset last commit or last n commits and keeps undone changes in working directory
     Undo {
@@ -88,8 +92,12 @@ pub(crate) enum Subcommands {
     /// Move staged files back to staging area; alias for `git-restore --staged`
     #[clap(alias = "u")]
     Unstage {
-        #[command(flatten)]
-        files: FileOperations,
+        /// which files to operate on
+        #[command(subcommand)]
+        which: Option<WhichFiles>,
+
+        /// Command arguments
+        args: Vec<String>,
     },
     /// Update local branch from origin without checking it out
     #[clap(alias = "unwind")]
@@ -99,22 +107,13 @@ pub(crate) enum Subcommands {
     },
 }
 
-#[derive(Debug, Clone, Args)]
-#[group(required = true, multiple = false)]
-pub(crate) struct FileOperations {
-    pub(crate) which: Option<WhichFiles>,
-
-    /// Command arguments
-    pub(crate) args: Vec<String>,
-}
-
 #[derive(Subcommand, Debug, Clone, Copy)]
 pub(crate) enum HookSubcommands {
     /// Precommit hook
     Precommit {},
 }
 
-#[derive(Debug, ValueEnum, Clone, Copy)]
+#[derive(Subcommand, Debug, Clone, Copy)]
 pub(crate) enum WhichFiles {
     All,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, HookSubcommands, LogLevel, Subcommands};
-use git::commands::{GitCommands, GitCommandResult, PRINT_COMMAND as GIT_PRINT_COMMAND};
+use git::commands::{GitCommandResult, GitCommands, PRINT_COMMAND as GIT_PRINT_COMMAND};
 use log::{debug, LevelFilter};
 use print::Print;
 use std::sync::atomic::Ordering;
@@ -36,7 +36,6 @@ fn main() -> ! {
 
     GIT_PRINT_COMMAND.store(cli.print_command, Ordering::Relaxed);
 
-    #[allow(unused_variables)]
     let result = match &cli.subcommand {
         Subcommands::A { args } => GitCommands::add(args),
         Subcommands::Aac { args } => GitCommands::aac(args),
@@ -51,23 +50,23 @@ fn main() -> ! {
         Subcommands::L { args } => GitCommands::log_oneline(args),
         Subcommands::Last { args } => GitCommands::last(args),
         Subcommands::Show { args } => GitCommands::show(args),
-        Subcommands::Restore { files } => {
-            if let Some(which) = files.which {
-                match which {
+        Subcommands::Restore { which, args } => {
+            if let Some(all) = which {
+                match all {
                     cli::WhichFiles::All => GitCommands::restore_all(),
                 }
             } else {
-                GitCommands::restore(&files.args)
+                GitCommands::restore(args)
             }
         }
         Subcommands::Undo { num } => GitCommands::undo(*num),
-        Subcommands::Unstage { files } => {
-            if let Some(which) = files.which {
+        Subcommands::Unstage { which, args } => {
+            if let Some(which) = which {
                 match which {
                     cli::WhichFiles::All => GitCommands::unstage_all(),
                 }
             } else {
-                GitCommands::unstage(&files.args)
+                GitCommands::unstage(args)
             }
         }
         Subcommands::Update { args } => GitCommands::update(args),


### PR DESCRIPTION
The way I was doing it with arg groups didn't work, so I redid it with a subcommand instead. It will now error if you call it with "all" followed by any arguments, which effectively makes the args and "all" subcommand mutually exclusive.